### PR TITLE
MAID-2738: fix packet loss handling

### DIFF
--- a/src/in_queue.rs
+++ b/src/in_queue.rs
@@ -210,6 +210,29 @@ fn in_range(ack_nr: u16, seq_nr: u16) -> bool {
 mod tests {
     use super::*;
 
+    mod in_range {
+        use super::*;
+
+        #[test]
+        fn when_ack_nr_is_equal_to_seq_nr_it_returns_false() {
+            assert!(!in_range(5, 5));
+        }
+
+        mod when_ack_nr_less_than_seq_nr {
+            use super::*;
+
+            #[test]
+            fn when_seq_nr_less_than_upper_limit_it_returns_true() {
+                assert!(in_range(4, 5));
+            }
+
+            #[test]
+            fn when_seq_nr_greater_than_upper_limit_it_returns_false() {
+                assert!(!in_range(4, 5 + MAX_DELTA_SEQ as u16));
+            }
+        }
+    }
+
     mod in_queue {
         use super::*;
 

--- a/src/out_queue.rs
+++ b/src/out_queue.rs
@@ -39,14 +39,14 @@ struct State {
     // Sequence number for the next packet
     seq_nr: u16,
 
-    // Sequence number of the last locally acked packet (aka, read)
-    local_ack: Option<u16>,
+    // Sequence number of the last locally seen packet which is yet to be acked.
+    last_in_ack: Option<u16>,
 
     // Bitfields indicating whether the next 32 packets have been received
     selective_acks: [u8; 4],
 
     // Last outbound ack
-    last_ack: Option<u16>,
+    last_out_ack: Option<u16>,
 
     // This is the number of bytes available in our inbound receive queue.
     local_window: u32,
@@ -61,13 +61,13 @@ struct State {
 }
 
 impl State {
-    fn new(connection_id: u16, seq_nr: u16, local_ack: Option<u16>) -> Self {
+    fn new(connection_id: u16, seq_nr: u16, last_in_ack: Option<u16>) -> Self {
         State {
             connection_id,
             seq_nr,
-            local_ack,
+            last_in_ack,
             selective_acks: [0; 4],
-            last_ack: None,
+            last_out_ack: None,
             local_window: MAX_WINDOW_SIZE as u32,
             created_at: Instant::now(),
             their_delay: 0,
@@ -126,10 +126,10 @@ const MAX_HEADER_SIZE: usize = 26;
 
 impl OutQueue {
     /// Create a new `OutQueue` with the specified `seq_nr` and `ack_nr`
-    pub fn new(connection_id: u16, seq_nr: u16, local_ack: Option<u16>) -> OutQueue {
+    pub fn new(connection_id: u16, seq_nr: u16, last_in_ack: Option<u16>) -> OutQueue {
         OutQueue {
             packets: VecDeque::new(),
-            state: State::new(connection_id, seq_nr, local_ack),
+            state: State::new(connection_id, seq_nr, last_in_ack),
             rtt: 0,
             rtt_variance: 0,
             // Start the max window at the packet size
@@ -146,7 +146,7 @@ impl OutQueue {
     /// ACKed.
     pub fn is_empty(&self) -> bool {
         // Only empty if all acks have been sent
-        self.packets.is_empty() && self.state.local_ack == self.state.last_ack
+        self.packets.is_empty() && self.state.last_in_ack == self.state.last_out_ack
     }
 
     /// Whenever a packet is received, the included timestamp is passed in here.
@@ -246,13 +246,13 @@ impl OutQueue {
         // the remote, *some* sort of state packet needs to be sent out in the
         // near term future.
 
-        if self.state.local_ack.is_none() {
-            // Also update the last_ack as this is the connection's first state
+        if self.state.last_in_ack.is_none() {
+            // Also update the last_out_ack as this is the connection's first state
             // packet which does not need to be acked.
-            self.state.last_ack = Some(val);
+            self.state.last_out_ack = Some(val);
         }
 
-        self.state.local_ack = Some(val);
+        self.state.last_in_ack = Some(val);
         self.state.selective_acks = selective_acks;
     }
 
@@ -264,7 +264,7 @@ impl OutQueue {
         }
 
         // Until a packet is received from the peer, the timeout is 1 second.
-        if self.state.local_ack.is_none() {
+        if self.state.last_in_ack.is_none() {
             return Some(Duration::from_secs(1));
         }
 
@@ -303,7 +303,7 @@ impl OutQueue {
     pub fn next(&mut self) -> Option<Next> {
         let ts = self.timestamp();
         let diff = self.state.their_delay;
-        let ack = self.state.local_ack.unwrap_or(0);
+        let ack = self.state.last_in_ack.unwrap_or(0);
         let selective_acks = self.state.selective_acks;
         let wnd_size = self.state.local_window;
 
@@ -338,11 +338,11 @@ impl OutQueue {
             return Some(Next::entry(entry, &mut self.state));
         }
 
-        if self.state.local_ack != self.state.last_ack {
+        if self.state.last_in_ack != self.state.last_out_ack {
             trace!(
                 "ack_required; local={:?}; last={:?}; seq_nr={:?}",
-                self.state.local_ack,
-                self.state.last_ack,
+                self.state.last_in_ack,
+                self.state.last_out_ack,
                 self.state.seq_nr
             );
 
@@ -471,6 +471,7 @@ impl<'a> Next<'a> {
         }
     }
 
+    /// Updates last acked packet number.
     pub fn sent(mut self) {
         if let Item::Entry(ref mut e) = self.item {
             // Increment the number of sends
@@ -480,7 +481,7 @@ impl<'a> Next<'a> {
             e.last_sent_at = Some(Instant::now());
         }
 
-        self.state.last_ack = self.state.local_ack;
+        self.state.last_out_ack = self.state.last_in_ack;
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1331,6 +1331,7 @@ impl Connection {
         } else {
             // TODO: validate the packet's ack_nr
 
+            self.out_queue.maybe_resend_ack_for(&packet);
             // Add the packet to the inbound queue. This handles ordering
             trace!("inqueue -- push packet");
             self.in_queue.push(packet)

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1012,8 +1012,15 @@ impl Inner {
         let receive_id = send_id + 1;
         let key = Key { receive_id, addr };
 
-        if self.connection_lookup.contains_key(&key) {
-            // Just ignore the packet...
+        if let Some(&token) = self.connection_lookup.get(&key) {
+            trace!(
+                "connection(id={}) already established, ignoring Syn packet",
+                send_id
+            );
+            // Ack packet anyway
+            let conn = &mut self.connections[token];
+            conn.out_queue.maybe_resend_ack_for(&packet);
+            conn.flush(&mut self.shared)?;
             return Ok(());
         }
 

--- a/src/test/keep_stream_alive.rs
+++ b/src/test/keep_stream_alive.rs
@@ -104,14 +104,17 @@ fn keep_stream_alive() {
                     .map_err(|(e, _listener_b)| {
                         panic!("accept error: {}", e);
                     })
-                    .and_then(|(stream_b_opt, _listener_b)| {
+                    .and_then(|(stream_b_opt, listener_b)| {
                         let stream_b = unwrap!(stream_b_opt);
                         trace!("accepted connection");
                         tokio_io::io::read_to_end(stream_b, Vec::new())
                             .map_err(|e| {
                                 panic!("read error: {}", e);
                             })
-                            .map(|(_stream_b, recv_data)| recv_data)
+                            .map(|(_stream_b, recv_data)| {
+                                drop(listener_b);
+                                recv_data
+                            })
                     })
             }));
             res.void_unwrap()


### PR DESCRIPTION
Sometimes State packets are also lost while in transit. Currently tokio-utp wouldn't resend State packet with the same ack number. This PR fixes that.