### PR TITLE
MAID-2994: allow connected udp sockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ futures = "0.1.16"
 log = "0.3.7"
 mio = "0.6.9"
 net-literals = "0.1.2"
+# TODO(povilas): need to update libc in netsim so that we could use latest
+# version V
+nix = "0.10.0"
 rand = "0.4"
 slab = "0.4.0"
 smallvec = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ extern crate futures;
 #[macro_use]
 extern crate hamcrest;
 extern crate mio;
+#[cfg(unix)]
+extern crate nix;
 #[cfg(test)]
 #[macro_use]
 extern crate net_literals;


### PR DESCRIPTION
On macOS when we connect UDP sockets to some specific peer, we can't use `sendto/recvfrom` functions anymore - they fail. This PR makes sure that, if we use connected UDP socket, we will use `send/recv` instead.